### PR TITLE
Fix typo in modifying filesystems

### DIFF
--- a/dualboot/modifying-filesystem.html
+++ b/dualboot/modifying-filesystem.html
@@ -48,7 +48,7 @@ And modify fstab using nano:
 
 	<p>In order for the secondary system to see this data as valid, it is also required to copy the main OS apticket (as the FUD images are signed with those)</p>
 
-	<p class="cli">cp -av /System/Libary/Caches/apticket.der /mnt1/System/Library/Caches</p>
+	<p class="cli">cp -av /System/Library/Caches/apticket.der /mnt1/System/Library/Caches</p>
 
 	<p>Now 3D touch feedback and home buttons will work as intended!</p></br>
 	


### PR DESCRIPTION
mcg/ralph misspelled library as libary. In cp -av /System/Libary/Caches/apticket.der /mnt1/System/Library/Caches
It should be cp -av /System/Library/Caches/apticket.der /mnt1/System/Library/Caches


